### PR TITLE
add topic descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,14 +96,17 @@
             }
           },
           "lightning": {
-            "external": true
+            "external": true,
+            "description": "Commands to create Aura components and Lightning web components."
           },
           "project": {
             "external": true,
+            "description": "Commands to set up a Salesforce DX project.",
             "subtopics": {}
           },
           "visualforce": {
             "external": true,
+            "description": "Commands to create Visualforce pages and components.",
             "subtopics": {}
           },
           "staticresource": {


### PR DESCRIPTION
Somehow the topic descriptions for force:visualforce, force:project, and force:lightning disappeared, so I'm adding them back.

@W-12339145@