### PR TITLE
fix: use "generate" instead of "create" in help

### DIFF
--- a/messages/analyticsTemplate.md
+++ b/messages/analyticsTemplate.md
@@ -1,10 +1,10 @@
 # summary
 
-Create a simple Analytics template. 
+Generate a simple Analytics template. 
 
 # description
 
-The metadata files associated with the Analytics template must be contained in a parent directory called "waveTemplates" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to create one or point to an existing one. 
+The metadata files associated with the Analytics template must be contained in a parent directory called "waveTemplates" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to generate one or point to an existing one. 
 
 # flags.name.summary
 
@@ -12,6 +12,6 @@ Name of the Analytics template.
 
 # examples
 
-- Create the metadata files for a simple Analytics template file called myTemplate in the force-app/main/default/waveTemplates directory:
+- Generate the metadata files for a simple Analytics template file called myTemplate in the force-app/main/default/waveTemplates directory:
 
   <%= config.bin %> <%= command.id %> --name myTemplate --output-dir force-app/main/default/waveTemplates

--- a/messages/apexClass.md
+++ b/messages/apexClass.md
@@ -1,10 +1,10 @@
 # summary
 
-Create an Apex class.
+Generate an Apex class.
 
 # description
 
-Creates the Apex *.cls file and associated metadata file. These files must be contained in a parent directory called "classes" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to create one or point to an existing one. 
+Generates the Apex *.cls file and associated metadata file. These files must be contained in a parent directory called "classes" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to generate one or point to an existing one. 
 
 # flags.name.summary
 
@@ -16,10 +16,10 @@ The name can be up to 40 characters and must start with a letter.
 
 # examples
 
-- Create two metadata files associated with the MyClass Apex class (MyClass.cls and MyClass.cls-meta.xml) in the current directory:
+- Generate two metadata files associated with the MyClass Apex class (MyClass.cls and MyClass.cls-meta.xml) in the current directory:
 
   <%= config.bin %> <%= command.id %> --name MyClass
 
-- Similar to previous example, but creates the files in the "force-app/main/default/classes" directory:
+- Similar to previous example, but generates the files in the "force-app/main/default/classes" directory:
 
   <%= config.bin %> <%= command.id %> --name MyClass --output-dir force-app/main/default/classes

--- a/messages/apexTrigger.md
+++ b/messages/apexTrigger.md
@@ -1,12 +1,12 @@
 # summary
 
-Create an Apex trigger.
+Generate an Apex trigger.
 
 # description
 
-Creates the Apex trigger *.trigger file and associated metadata file. These files must be contained in a parent directory called "triggers" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to create one or point to an existing one. 
+Generates the Apex trigger *.trigger file and associated metadata file. These files must be contained in a parent directory called "triggers" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to generate one or point to an existing one. 
 
-If you don't specify the --sobject flag, the .trigger file contains the generic placeholder SOBJECT; replace it with the Salesforce object you want to create a trigger for. If you don't specify --event, "before insert" is used. 
+If you don't specify the --sobject flag, the .trigger file contains the generic placeholder SOBJECT; replace it with the Salesforce object you want to generate a trigger for. If you don't specify --event, "before insert" is used. 
 
 # flags.event
 
@@ -22,19 +22,19 @@ The name can be up to 40 characters and must start with a letter.
 
 # flags.sobject
 
-Salesforce object to create a trigger on.
+Salesforce object to generate a trigger on.
 
 # examples
 
-- Create two files associated with the MyTrigger Apex trigger (MyTrigger.trigger and MyTrigger.trigger-meta.xml) in the current directory:
+- Generate two files associated with the MyTrigger Apex trigger (MyTrigger.trigger and MyTrigger.trigger-meta.xml) in the current directory:
 
   <%= config.bin %> <%= command.id %> --name MyTrigger
 
-- Similar to the previous example, but create the files in the "force-app/main/default/triggers" directory:
+- Similar to the previous example, but generate the files in the "force-app/main/default/triggers" directory:
 
   <%= config.bin %> <%= command.id %> --name MyTrigger --output-dir force-app/main/default/triggers
 
-- Generate files to create a trigger that fires on the Account object before and after an insert:
+- Generate files for a trigger that fires on the Account object before and after an insert:
 
   <%= config.bin %> <%= command.id %> --name MyTrigger --sobject Account --event "before insert,after insert"
 

--- a/messages/lightning.md
+++ b/messages/lightning.md
@@ -1,10 +1,10 @@
 # summary
 
-Create a Lightning %s.
+Generate a Lightning %s.
 
 # description
 
-Creates a Lightning %s bundle in the specified directory or the current working directory. The bundle consists of multiple files in a folder with the designated name.
+Generates a Lightning %s bundle in the specified directory or the current working directory. The bundle consists of multiple files in a folder with the designated name.
 
 # flags.name
 
@@ -16,7 +16,7 @@ The name can be up to 40 characters and must start with a letter.
 
 # flags.internal
 
-Create lightning bundles without creating a -meta.xml file.
+Generate lightning bundles without creating a -meta.xml file.
 
 # flags.template
 

--- a/messages/lightningApp.md
+++ b/messages/lightningApp.md
@@ -1,9 +1,9 @@
 # examples
 
-- Create the metadata files for a Lightning app bundle called "myapp" in the current directory:
+- Generate the metadata files for a Lightning app bundle called "myapp" in the current directory:
 
   <%= config.bin %> <%= command.id %> --name myapp
 
-- Similar to the previous example, but create the files in the "force-app/main/default/aura" directory:
+- Similar to the previous example, but generate the files in the "force-app/main/default/aura" directory:
 
   <%= config.bin %> <%= command.id %> --name myapp --output-dir force-app/main/default/aura

--- a/messages/lightningCmp.md
+++ b/messages/lightningCmp.md
@@ -1,30 +1,30 @@
 # examples
 
-- Create the metadata files for an Aura component bundle in the current directory:
+- Generate the metadata files for an Aura component bundle in the current directory:
 
   <%= config.bin %> <%= command.id %> --name mycomponent
 
-- Create a Lightning web component bundle in the current directory:
+- Generate a Lightning web component bundle in the current directory:
 
   <%= config.bin %> <%= command.id %> --name mycomponent --type lwc
 
-- Create an Aura component bundle in the "force-app/main/default/aura" directory:
+- Generate an Aura component bundle in the "force-app/main/default/aura" directory:
 
   <%= config.bin %> <%= command.id %> --name mycomponent --output-dir force-app/main/default/aura
 
-- Create a Lightning web component bundle in the "force-app/main/default/lwc" directory:
+- Generate a Lightning web component bundle in the "force-app/main/default/lwc" directory:
 
   <%= config.bin %> <%= command.id %> --name mycomponent --type lwc --output-dir force-app/main/default/lwc
 
 # summary
 
-Create a bundle for an Aura component or a Lightning web component.
+Generate a bundle for an Aura component or a Lightning web component.
 
 # description
 
-Creates the bundle in the specified directory or the current working directory. The bundle consists of multiple files in a directory with the designated name.  Lightning web components are contained in the directory with name "lwc", Aura components in "aura".
+Generates the bundle in the specified directory or the current working directory. The bundle consists of multiple files in a directory with the designated name.  Lightning web components are contained in the directory with name "lwc", Aura components in "aura".
 
-To create a Lightning web component, pass "--type lwc" to the command. If you don’t specify --type, Salesforce CLI creates an Aura component by default.
+To generate a Lightning web component, pass "--type lwc" to the command. If you don’t specify --type, Salesforce CLI generates an Aura component by default.
 
 # flags.type
 

--- a/messages/lightningEvent.md
+++ b/messages/lightningEvent.md
@@ -1,9 +1,9 @@
 # examples
 
-- Create the metadata files for a Lightning event bundle called "myevent" in the current directory:
+- Generate the metadata files for a Lightning event bundle called "myevent" in the current directory:
 
   <%= config.bin %> <%= command.id %> --name myevent
  
-- Similar to previous example, but create the files in the "force-app/main/default/aura" directory:
+- Similar to previous example, but generate the files in the "force-app/main/default/aura" directory:
 
   <%= config.bin %> <%= command.id %> --name myevent --output-dir force-app/main/default/aura

--- a/messages/lightningInterface.md
+++ b/messages/lightningInterface.md
@@ -1,9 +1,9 @@
 # examples
 
-- Create the metadata files for a Lightning interface bundle called "myinterface" in the current directory:
+- Generate the metadata files for a Lightning interface bundle called "myinterface" in the current directory:
 
   <%= config.bin %> <%= command.id %> --name myinterface
 
-- Similar to the previous example but create the files in the "force-app/main/default/aura" directory:
+- Similar to the previous example but generate the files in the "force-app/main/default/aura" directory:
 
   <%= config.bin %> <%= command.id %> --name myinterface --output-dir force-app/main/default/aura

--- a/messages/lightningTest.md
+++ b/messages/lightningTest.md
@@ -1,20 +1,20 @@
 # examples
 
-- Create the metadata files for the Lightning test called MyLightningTest in the current directory:
+- Generate the metadata files for the Lightning test called MyLightningTest in the current directory:
 
   <%= config.bin %> <%= command.id %> --name MyLightningTest
 
-- Similar to the previous example but create the files in the "force-app/main/default/lightningTests" directory:
+- Similar to the previous example but generate the files in the "force-app/main/default/lightningTests" directory:
 
   <%= config.bin %> <%= command.id %> --name MyLightningTest --output-dir force-app/main/default/lightningTests
 
 # summary
 
-Create a Lightning test.
+Generate a Lightning test.
 
 # description
 
-Creates the test in the specified directory or the current working directory. The .resource file and associated metadata file are created.
+Generates the test in the specified directory or the current working directory. The .resource file and associated metadata file are generated.
 
 # flags.name.description
 

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -12,11 +12,11 @@ If you don’t specify an outputdir, we create a subfolder in your current worki
 
 # flags.template
 
-template to use for file creation
+Template to use for file creation.
 
 # flags.template.description
 
-The template to use to create the file. Supplied parameter values or default values are filled into a copy of the template.
+Supplied parameter values or default values are filled into a copy of the template.
 
 # TargetDirOutput
 

--- a/messages/project.md
+++ b/messages/project.md
@@ -1,28 +1,28 @@
 # summary
 
-Create a Salesforce DX project.
+Generate a Salesforce DX project.
 
 # description
 
-A Salesforce DX project has a specific structure and a configuration file (sfdx-project.json) that identifies the directory as a Salesforce DX project. This command creates the necessary configuration files and directories to get you started.
+A Salesforce DX project has a specific structure and a configuration file (sfdx-project.json) that identifies the directory as a Salesforce DX project. This command generates the necessary configuration files and directories to get you started.
 
 By default, the generated sfdx-project.json file sets the sourceApiVersion property to the default API version currently used by Salesforce CLI. To specify a different version, set the apiVersion configuration variable. For example: "sf config set apiVersion=57.0 --global".
 
 # examples
 
-- Create a project called "mywork":
+- Generate a project called "mywork":
 
   <%= config.bin %> <%= command.id %> --name mywork
 
-- Similar to previous example, but create the files in a directory called "myapp":
+- Similar to previous example, but generate the files in a directory called "myapp":
 
   <%= config.bin %> <%= command.id %> --name mywork --default-package-dir myapp
 
-- Similar to prevoius example, but also create a default package.xml manifest file:
+- Similar to prevoius example, but also generate a default package.xml manifest file:
 
   <%= config.bin %> <%= command.id %> --name mywork --default-package-dir myapp --manifest
 
-- Create a project with the minimum files and directories:
+- Generate a project with the minimum files and directories:
 
   <%= config.bin %> <%= command.id %> --name mywork --template empty
 
@@ -32,7 +32,7 @@ Name of the generated project.
 
 # flags.name.description
 
-Creates a project directory with this name; any valid directory name is accepted. Also sets the "name" property in the sfdx-project.json file to this name.
+Generates a project directory with this name; any valid directory name is accepted. Also sets the "name" property in the sfdx-project.json file to this name.
 
 # flags.template
 

--- a/messages/staticResource.md
+++ b/messages/staticResource.md
@@ -1,14 +1,14 @@
 # summary
 
-Create a static resource.
+Generate a static resource.
 
 # description
 
-Creates the metadata resource file in the specified directory or the current working directory. Static resource files must be contained in a parent directory called "staticresources" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to create one or point to an existing one.
+Generates the metadata resource file in the specified directory or the current working directory. Static resource files must be contained in a parent directory called "staticresources" in your package directory. Either run this command from an existing directory of this name, or use the --output-dir flag to create one or point to an existing one.
 
 # examples
 
-- Create the metadata file for a static resource called MyResource in the current directory:
+- Generate the metadata file for a static resource called MyResource in the current directory:
 
   <%= config.bin %> <%= command.id %> --name MyResource
 
@@ -16,7 +16,7 @@ Creates the metadata resource file in the specified directory or the current wor
 
   <%= config.bin %> <%= command.id %> --name MyResource --type application/json
 
-- Create the resource file in the "force-app/main/default/staticresources" directory:
+- Generate the resource file in the "force-app/main/default/staticresources" directory:
 
   <%= config.bin %> <%= command.id %> --name MyResource --output-dir force-app/main/default/staticresources
 

--- a/messages/vf.md
+++ b/messages/vf.md
@@ -1,10 +1,10 @@
 # summary
 
-Create a Visualforce %s.
+Generate a Visualforce %s.
 
 # description
 
-The command creates the .%s file and associated metadata file in the specified directory or the current working directory by default.
+The command generates the .%s file and associated metadata file in the specified directory or the current working directory by default.
 
 # flags.name
 
@@ -20,20 +20,20 @@ Visualforce %s label.
 
 # examples.component
 
-- Create the metadata files for a Visualforce component in the current directory:
+- Generate the metadata files for a Visualforce component in the current directory:
 
   <%= config.bin %> <%= command.id %> --name mycomponent --label mylabel
 
-- Similar to previous example, but create the files in the directory "force-app/main/default/components":
+- Similar to previous example, but generate the files in the directory "force-app/main/default/components":
 
   <%= config.bin %> <%= command.id %> --name mycomponent --label mylabel --output-dir components
 
 # examples.page
 
-- Create the metadata files for a Visualforce page in the current directory:
+- Generate the metadata files for a Visualforce page in the current directory:
 
   <%= config.bin %> <%= command.id %> --name mypage --label mylabel
 
-- Similar to previous example, but create the files in the directory "force-app/main/default/pages":
+- Similar to previous example, but generate the files in the directory "force-app/main/default/pages":
 
   <%= config.bin %> <%= command.id %> --name mypage --label mylabel --output-dir pages


### PR DESCRIPTION
### What does this PR do?

Uses the word "generate" instead of "create" in the help to better align with the command names.

### What issues does this PR fix or reference?

@W-12460651@