### PR TITLE
Sm/api-version-on-project-generate

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -67,6 +67,7 @@
     "command": "project:generate",
     "plugin": "@salesforce/plugin-templates",
     "flags": [
+      "api-version",
       "default-package-dir",
       "json",
       "login-url",

--- a/messages/project.md
+++ b/messages/project.md
@@ -62,6 +62,10 @@ The analytics template provides similar files and the force-app/main/default/wav
 
 Namespace associated with this project and any connected scratch orgs.
 
+# flags.api-version.summary
+
+Will set this version as sourceApiVersion in the sfdx-project.json file
+
 # flags.packagedir
 
 Default package directory name.

--- a/src/commands/project/generate.ts
+++ b/src/commands/project/generate.ts
@@ -64,6 +64,9 @@ export default class Project extends SfCommand<CreateOutput> {
       deprecateAliases: true,
     }),
     loglevel,
+    'api-version': Flags.orgApiVersion({
+      summary: messages.getMessage('flags.api-version.summary'),
+    }),
   };
   public async run(): Promise<CreateOutput> {
     const { flags } = await this.parse(Project);
@@ -78,6 +81,7 @@ export default class Project extends SfCommand<CreateOutput> {
       // namespace is a reserved keyword for the generator
       ns: flags.namespace,
       defaultpackagedir: flags['default-package-dir'],
+      apiversion: flags['api-version'],
     };
     return runGenerator({
       generator: ProjectGenerator,

--- a/test/commands/project/create.nut.ts
+++ b/test/commands/project/create.nut.ts
@@ -158,6 +158,14 @@ describe('Project creation tests:', () => {
       }
     });
 
+    it('should create a project with specified api version', () => {
+      execCmd('force:project:create --projectname apiVersionTest --api-version 50.0', { ensureExitCode: 0 });
+      assert.fileContent(
+        path.join(session.project.dir, 'apiVersionTest', 'sfdx-project.json'),
+        '"sourceApiVersion": "50.0"'
+      );
+    });
+
     it('should create project with footest name and manifest folder', () => {
       execCmd('force:project:create --projectname footest --manifest', { ensureExitCode: 0 });
       assert.file([path.join(session.project.dir, 'footest', 'manifest', 'package.xml')]);


### PR DESCRIPTION
### What does this PR do?
you can specify the api version on project:generate and it'll set that as the sourceApiVersion in the sfdx-project.json

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1939
@W-12551179@