### PR TITLE
fix: remove unnecessary flag value assignment

### DIFF
--- a/src/commands/project/generate.ts
+++ b/src/commands/project/generate.ts
@@ -71,7 +71,6 @@ export default class Project extends SfCommand<CreateOutput> {
   };
   public async run(): Promise<CreateOutput> {
     const { flags } = await this.parse(Project);
-    flags.ns = flags.namespace;
 
     const flagsAsOptions: ProjectOptions = {
       projectname: flags.name,


### PR DESCRIPTION
### What does this PR do?

Fix compilation errors when `SfCommand` has `baseFlags`. Can be merged independently of https://github.com/salesforcecli/sf-plugins-core/pull/519

### What issues does this PR fix or reference?
@W-15213828@