### PR TITLE
fix(deps): bump @salesforce/templates to 66.7.9 @W-21940169@

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Local Salesforce scaffolds with their own .git (breaks parent `git add .`)
+hello-React-App1/
+hello-React-App2/
+
 # -- CLEAN
 tmp/
 # use yarn by default, so ignore npm

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Local Salesforce scaffolds with their own .git (breaks parent `git add .`)
-hello-React-App1/
-hello-React-App2/
-
 # -- CLEAN
 tmp/
 # use yarn by default, so ignore npm

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@salesforce/core": "^8.27.1",
     "@salesforce/sf-plugins-core": "^12",
-    "@salesforce/templates": "^66.7.8"
+    "@salesforce/templates": "^66.7.9"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.3.14",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@salesforce/core": "^8.27.1",
     "@salesforce/sf-plugins-core": "^12",
-    "@salesforce/templates": "^66.7.9"
+    "@salesforce/templates": "^66.7.10"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.3.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,10 +1649,10 @@
     cli-progress "^3.12.0"
     terminal-link "^3.0.0"
 
-"@salesforce/templates@^66.7.9":
-  version "66.7.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-66.7.9.tgz#a94777a1e3fd67cdc68118d22488cc53c0efc5da"
-  integrity sha512-dhezRgU0VpvYHfRAHjyAXZPAUrizpUQG3g5BalDBwBTc4DYowqb6o8NEgcxNb5Hs0ZJP+O4hElozMPknTLIvSQ==
+"@salesforce/templates@^66.7.10":
+  version "66.7.10"
+  resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-66.7.10.tgz#576d041133a60710a5ebef626d5b9493857e0dfc"
+  integrity sha512-zIaYUpZHfvRa5nP8LwA5dKBaoBo40fFoch38iFw519gFJ9CXmcRu5crE7BVQ03trfj6pNsaUJSYl6cSIjsdy9A==
   dependencies:
     "@salesforce/kit" "^3.2.6"
     ejs "^3.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,10 +1649,10 @@
     cli-progress "^3.12.0"
     terminal-link "^3.0.0"
 
-"@salesforce/templates@^66.7.8":
-  version "66.7.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-66.7.8.tgz#0e8b698b4217b953a0d35ca028e1b74c92cb2f2c"
-  integrity sha512-13oYlo6lYRO00fz3GpRlVEhdPaGQbGlc1k89vF1+WfS+2ks7a2ANsxiBfn2uhr1McpKAldAA+q8+d/Hg+lBxGg==
+"@salesforce/templates@^66.7.9":
+  version "66.7.9"
+  resolved "https://registry.yarnpkg.com/@salesforce/templates/-/templates-66.7.9.tgz#a94777a1e3fd67cdc68118d22488cc53c0efc5da"
+  integrity sha512-dhezRgU0VpvYHfRAHjyAXZPAUrizpUQG3g5BalDBwBTc4DYowqb6o8NEgcxNb5Hs0ZJP+O4hElozMPknTLIvSQ==
   dependencies:
     "@salesforce/kit" "^3.2.6"
     ejs "^3.1.10"


### PR DESCRIPTION
### What does this PR do?

- Bumps `@salesforce/templates` from `66.7.8` to `66.7.9` (aligned with experience next-gen / UI bundle updates).
- Adds `hello-React-App1/` and `hello-React-App2/` to `.gitignore` so local Salesforce scaffolds that contain their own `.git` directory do not break `git add .` in this repository.

### What issues does this PR fix or reference?

N/A — dependency refresh and developer workflow fix for nested git checkouts.

 @W-21940169@