### PR TITLE
refactor: use top-level @salesforce/templates exports instead of deep lib/ imports - W-22245234

### DIFF
--- a/src/commands/template/generate/apex/class.ts
+++ b/src/commands/template/generate/apex/class.ts
@@ -6,8 +6,7 @@
  */
 
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand, Ux } from '@salesforce/sf-plugins-core';
-import { ApexClassOptions, CreateOutput, TemplateType } from '@salesforce/templates';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
+import { ApexClassOptions, CreateOutput, CreateUtil, TemplateType } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
 import { runGenerator, getCustomTemplates } from '../../../../utils/templateCommand.js';
 import { outputDirFlag } from '../../../../utils/flags.js';

--- a/src/commands/template/generate/apex/trigger.ts
+++ b/src/commands/template/generate/apex/trigger.ts
@@ -13,8 +13,7 @@ import {
   SfCommand,
   Ux,
 } from '@salesforce/sf-plugins-core';
-import { ApexTriggerOptions, CreateOutput, TemplateType } from '@salesforce/templates';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
+import { ApexTriggerOptions, CreateOutput, CreateUtil, TemplateType } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
 import { getCustomTemplates, runGenerator } from '../../../../utils/templateCommand.js';
 import { outputDirFlag } from '../../../../utils/flags.js';

--- a/src/commands/template/generate/lightning/app.ts
+++ b/src/commands/template/generate/lightning/app.ts
@@ -6,8 +6,7 @@
  */
 
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand, Ux } from '@salesforce/sf-plugins-core';
-import { CreateOutput, LightningAppOptions, TemplateType } from '@salesforce/templates';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
+import { CreateOutput, CreateUtil, LightningAppOptions, TemplateType } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
 import { getCustomTemplates, runGenerator } from '../../../../utils/templateCommand.js';
 import { internalFlag, outputDirFlagLightning } from '../../../../utils/flags.js';

--- a/src/commands/template/generate/lightning/event.ts
+++ b/src/commands/template/generate/lightning/event.ts
@@ -6,8 +6,7 @@
  */
 
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand, Ux } from '@salesforce/sf-plugins-core';
-import { CreateOutput, LightningEventOptions, TemplateType } from '@salesforce/templates';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
+import { CreateOutput, CreateUtil, LightningEventOptions, TemplateType } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
 import { getCustomTemplates, runGenerator } from '../../../../utils/templateCommand.js';
 import { internalFlag, outputDirFlagLightning } from '../../../../utils/flags.js';

--- a/src/commands/template/generate/lightning/interface.ts
+++ b/src/commands/template/generate/lightning/interface.ts
@@ -6,8 +6,7 @@
  */
 
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand, Ux } from '@salesforce/sf-plugins-core';
-import { CreateOutput, LightningInterfaceOptions, TemplateType } from '@salesforce/templates';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
+import { CreateOutput, CreateUtil, LightningInterfaceOptions, TemplateType } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
 import { getCustomTemplates, runGenerator } from '../../../../utils/templateCommand.js';
 import { internalFlag, outputDirFlagLightning } from '../../../../utils/flags.js';

--- a/src/commands/template/generate/lightning/test.ts
+++ b/src/commands/template/generate/lightning/test.ts
@@ -6,8 +6,7 @@
  */
 
 import { Flags, loglevel, SfCommand, orgApiVersionFlagWithDeprecations, Ux } from '@salesforce/sf-plugins-core';
-import { CreateOutput, LightningTestOptions, TemplateType } from '@salesforce/templates';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
+import { CreateOutput, CreateUtil, LightningTestOptions, TemplateType } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
 import { getCustomTemplates, runGenerator } from '../../../../utils/templateCommand.js';
 import { internalFlag, outputDirFlagLightning } from '../../../../utils/flags.js';

--- a/src/commands/template/generate/visualforce/component.ts
+++ b/src/commands/template/generate/visualforce/component.ts
@@ -6,9 +6,8 @@
  */
 
 import { Flags, SfCommand, orgApiVersionFlagWithDeprecations, Ux, loglevel } from '@salesforce/sf-plugins-core';
-import { CreateOutput, TemplateType, VisualforceComponentOptions } from '@salesforce/templates';
+import { CreateOutput, CreateUtil, TemplateType, VisualforceComponentOptions } from '@salesforce/templates';
 import { Messages } from '@salesforce/core';
-import { CreateUtil } from '@salesforce/templates/lib/utils/index.js';
 import { outputDirFlag } from '../../../../utils/flags.js';
 import { runGenerator, getCustomTemplates } from '../../../../utils/templateCommand.js';
 const visualforceComponentFileSuffix = /.component$/;


### PR DESCRIPTION
## Summary
- Replace deep imports from `@salesforce/templates/lib/utils/index.js` with top-level `@salesforce/templates` in 7 command files
- `CreateUtil` is now exported from the package root, so deep `lib/` paths are unnecessary

### What issues does this PR fix or reference?
@W-22245234@


Made with [Cursor](https://cursor.com)