### PR TITLE
@W-22992564 feat: add angularbasic option to sf template generate ui-bundle

### DIFF
--- a/messages/ui-bundle.generate.md
+++ b/messages/ui-bundle.generate.md
@@ -1,6 +1,6 @@
 # summary
 
-Generate a UI bundle, which contains the code and metadata to build a UI experience that uses non-native Salesforce frameworks, such as React.
+Generate a UI bundle, which contains the code and metadata to build a UI experience that uses non-native Salesforce frameworks, such as React or Angular.
 
 # description
 
@@ -8,7 +8,7 @@ Salesforce provides native UI frameworks, such as Lighting Web Components (LWC),
 
 These non-native UI experiences are defined by the "UIBundle" metadata type in your DX project. Use this command to generate the required DX project structure and files. For example, when you run this command and specify the name MyUiBundle, then the files are generated into a "uiBundles/MyUiBundle" directory. Use the --output-dir flag to specify a different directory.
 
-Use the --template flag for generating the files to get started with a speciic UI framework, such as React. Check out the README.md file in the generated "uiBundles/<bundlename>" directory for more information about the template.
+Use the --template flag for generating the files to get started with a specific UI framework, such as React or Angular. Check out the README.md file in the generated "uiBundles/<bundlename>" directory for more information about the template.
 
 # examples
 
@@ -19,6 +19,10 @@ Use the --template flag for generating the files to get started with a speciic U
 - Generate a React-based UI bundle:
 
   <%= config.bin %> <%= command.id %> --name MyReactApp --template reactbasic
+
+- Generate an Angular-based UI bundle:
+
+  <%= config.bin %> <%= command.id %> --name MyAngularApp --template angularbasic
 
 - Generate the React-based UI bundle in the "force-app/main/default/uiBundles" directory:
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@salesforce/core": "^8.31.2",
     "@salesforce/sf-plugins-core": "^12",
-    "@salesforce/templates": "^66.10.2"
+    "@salesforce/templates": "^66.10.4"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.3.24",

--- a/src/commands/template/generate/ui-bundle/index.ts
+++ b/src/commands/template/generate/ui-bundle/index.ts
@@ -34,7 +34,7 @@ export default class UiBundleGenerate extends SfCommand<CreateOutput> {
       summary: messages.getMessage('flags.template.summary'),
       description: messages.getMessage('flags.template.description'),
       default: 'default',
-      options: ['default', 'reactbasic'],
+      options: ['default', 'reactbasic', 'angularbasic'],
     }),
     label: Flags.string({
       char: 'l',

--- a/test/commands/template/generate/ui-bundle/index.nut.ts
+++ b/test/commands/template/generate/ui-bundle/index.nut.ts
@@ -151,7 +151,7 @@ describe('template generate ui-bundle:', () => {
       });
       assert.file([
         path.join(outputDir, 'MyAngularApp', 'MyAngularApp.uibundle-meta.xml'),
-        path.join(outputDir, 'MyAngularApp', 'index.html'),
+        path.join(outputDir, 'MyAngularApp', 'src', 'index.html'),
         path.join(outputDir, 'MyAngularApp', 'ui-bundle.json'),
         path.join(outputDir, 'MyAngularApp', 'package.json'),
       ]);

--- a/test/commands/template/generate/ui-bundle/index.nut.ts
+++ b/test/commands/template/generate/ui-bundle/index.nut.ts
@@ -143,6 +143,21 @@ describe('template generate ui-bundle:', () => {
     });
   });
 
+  describe('Check UI bundle creation with angularbasic template', () => {
+    it('should create Angular UI bundle with all required files', () => {
+      const outputDir = path.join(projectDir, 'force-app', 'main', 'default', UI_BUNDLES_DIR);
+      execCmd(`template generate ui-bundle --name MyAngularApp --template angularbasic --output-dir "${outputDir}"`, {
+        ensureExitCode: 0,
+      });
+      assert.file([
+        path.join(outputDir, 'MyAngularApp', 'MyAngularApp.uibundle-meta.xml'),
+        path.join(outputDir, 'MyAngularApp', 'index.html'),
+        path.join(outputDir, 'MyAngularApp', 'ui-bundle.json'),
+        path.join(outputDir, 'MyAngularApp', 'package.json'),
+      ]);
+    });
+  });
+
   describe('Check that all invalid name errors are thrown', () => {
     it('should throw a missing name error', () => {
       const stderr = execCmd('template generate ui-bundle').shellOutput.stderr;


### PR DESCRIPTION
@W-22992564@
## Summary

Adds `angularbasic` as a new template option for `sf template generate ui-bundle`, enabling Angular-based UI bundle scaffolding alongside the existing `default` and `reactbasic` templates.

## Changes

- Added `angularbasic` to the `--template` flag options in the ui-bundle generate command
- Added usage example in `messages/ui-bundle.generate.md`
- Added NUT test verifying Angular UI bundle generation produces expected files

## Dependencies

- `forcedotcom/salesforcedx-templates` — adds the `generateAngularBasic()` generator method
- `webapps` — adds the `@salesforce/ui-bundle-template-base-angular-app` source package and `@salesforce/angular-plugin-ui-bundle` dev server wrapper

## Testing

```bash
sf template generate ui-bundle --name MyAngularApp --template angularbasic
```

Generates a complete Angular standalone app with:
- `angular.json`, `tsconfig.json`, `package.json`
- `src/` with Angular components, routing, Tailwind CSS
- `.uibundle-meta.xml` with correct API version
- `ui-bundle.json` manifest for dev server proxy