### PR TITLE
feat: add vuebasic template option to ui-bundle generate + unit tests

### DIFF
--- a/messages/ui-bundle.generate.md
+++ b/messages/ui-bundle.generate.md
@@ -20,6 +20,10 @@ Use the --template flag for generating the files to get started with a speciic U
 
   <%= config.bin %> <%= command.id %> --name MyReactApp --template reactbasic
 
+- Generate a Vue-based UI bundle:
+
+  <%= config.bin %> <%= command.id %> --name MyVueApp --template vuebasic
+
 - Generate the React-based UI bundle in the "force-app/main/default/uiBundles" directory:
 
   <%= config.bin %> <%= command.id %> --name MyUiBundle --template reactbasic --output-dir force-app/main/default/uiBundles

--- a/src/commands/template/generate/ui-bundle/index.ts
+++ b/src/commands/template/generate/ui-bundle/index.ts
@@ -32,7 +32,7 @@ export default class UiBundleGenerate extends SfCommand<CreateOutput> {
       summary: messages.getMessage('flags.template.summary'),
       description: messages.getMessage('flags.template.description'),
       default: 'default',
-      options: ['default', 'reactbasic'],
+      options: ['default', 'reactbasic', 'vuebasic'],
     }),
     label: Flags.string({
       char: 'l',

--- a/test/commands/template/generate/ui-bundle/index.nut.ts
+++ b/test/commands/template/generate/ui-bundle/index.nut.ts
@@ -79,6 +79,22 @@ describe('template generate ui-bundle:', () => {
     });
   });
 
+  // TODO: unskip once @salesforce/templates ships the vuebasic template
+  describe.skip('Check UI bundle creation with vuebasic template', () => {
+    it('should create Vue UI bundle with all required files', () => {
+      const outputDir = path.join(projectDir, 'force-app', 'main', 'default', UI_BUNDLES_DIR);
+      execCmd(`template generate ui-bundle --name MyVueApp --template vuebasic --output-dir "${outputDir}"`, {
+        ensureExitCode: 0,
+      });
+      assert.file([
+        path.join(outputDir, 'MyVueApp', 'MyVueApp.uibundle-meta.xml'),
+        path.join(outputDir, 'MyVueApp', 'index.html'),
+        path.join(outputDir, 'MyVueApp', 'ui-bundle.json'),
+        path.join(outputDir, 'MyVueApp', 'package.json'),
+      ]);
+    });
+  });
+
   describe('Check that all invalid name errors are thrown', () => {
     it('should throw a missing name error', () => {
       const stderr = execCmd('template generate ui-bundle').shellOutput.stderr;

--- a/test/commands/template/generate/ui-bundle/index.test.ts
+++ b/test/commands/template/generate/ui-bundle/index.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import UiBundleGenerate from '../../../../../src/commands/template/generate/ui-bundle/index.js';
+
+describe('template:generate:ui-bundle', () => {
+  it('should include vuebasic in --template flag options', () => {
+    const templateFlag = UiBundleGenerate.flags.template;
+    expect(templateFlag.options).to.include('vuebasic');
+  });
+
+  it('should include all expected --template flag options', () => {
+    const templateFlag = UiBundleGenerate.flags.template;
+    expect(templateFlag.options).to.deep.equal(['default', 'reactbasic', 'vuebasic']);
+  });
+
+  it('should default --template to default', () => {
+    const templateFlag = UiBundleGenerate.flags.template;
+    expect(templateFlag.default).to.equal('default');
+  });
+
+  it('should accept --template vuebasic without validation error', async () => {
+    try {
+      await UiBundleGenerate.run(['--name', 'TestBundle', '--template', 'vuebasic']);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.not.include('Expected --template=vuebasic to be one of');
+    }
+  });
+
+  it('should reject invalid --template value', async () => {
+    try {
+      await UiBundleGenerate.run(['--name', 'TestBundle', '--template', 'invalidtemplate']);
+      expect.fail('Should have thrown an error');
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.include('Expected --template=invalidtemplate to be one of');
+    }
+  });
+
+  it('should require name flag', async () => {
+    try {
+      await UiBundleGenerate.run([]);
+      expect.fail('Should have thrown an error');
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).to.include('Missing required flag');
+    }
+  });
+});


### PR DESCRIPTION
## Add `vuebasic` template option to `sf template generate ui-bundle`

Exposes the `vuebasic` option on the `--template` flag of
`sf template generate ui-bundle`, so the CLI can scaffold a Vue 3 UI bundle
(backed by the `vuebasic` generator in `@salesforce/templates`).

### Feature changes (already on the branch)
- `src/commands/template/generate/ui-bundle/index.ts` — added `vuebasic` to the
  `--template` flag's accepted options.
- `messages/ui-bundle.generate.md` — added a `vuebasic` usage example.
- `test/commands/template/generate/ui-bundle/index.nut.ts` — added a `vuebasic`
  NUT, intentionally `describe.skip`'d until `@salesforce/templates` with vuebasic
  is published (NUTs need org access + the published upstream).

### Tests added in this PR
`test/commands/template/generate/ui-bundle/index.test.ts` — offline unit tests
that verify the flag change without an org or the published generator:
- `vuebasic` is in the `--template` flag `options` array
- the options array is `['default', 'reactbasic', 'vuebasic']`
- `--template` defaults to `'default'`
- `--template vuebasic` parses without a validation error
- an invalid `--template` value is rejected with the expected message
- `--name` is required

### Verification
- `npx tsc -b` → **green**
- `npx mocha "test/**/*.test.ts"` → **14 passing** (the `vuebasic` NUT stays skipped)
