### PR TITLE
fix: warn on local org-custom-metadata-templates config @W-23595931@

### DIFF
--- a/src/utils/templateCommand.ts
+++ b/src/utils/templateCommand.ts
@@ -6,7 +6,7 @@
  */
 
 import { Ux } from '@salesforce/sf-plugins-core';
-import { ConfigAggregator, OrgConfigProperties } from '@salesforce/core';
+import { ConfigAggregator, Lifecycle, OrgConfigProperties } from '@salesforce/core';
 import { CreateOutput, TemplateOptions, TemplateService, TemplateType } from '@salesforce/templates';
 
 export type GeneratorInputs = {
@@ -25,8 +25,15 @@ export async function runGenerator({ ux, templates, templateType, opts }: Genera
 
 export const getCustomTemplates = (configAggregator: ConfigAggregator): string | undefined => {
   try {
-    // we're still accessing the old `customOrgMetadataTemplates` key, but this is deprecated and we'll use the new key to access the value
-    return configAggregator.getPropertyValue(OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES) as string;
+    const info = configAggregator.getInfo(OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES);
+    if (info.isLocal()) {
+      void Lifecycle.getInstance().emitWarning(
+        'Setting "org-custom-metadata-templates" in local project config (.sf/config.json) is deprecated ' +
+          'due to security concerns and will stop being honored in a future release. ' +
+          'Use "sf config set --global org-custom-metadata-templates=<path>" instead.'
+      );
+    }
+    return info.value as string | undefined;
   } catch (err) {
     return undefined;
   }

--- a/test/utils/templateCommand.test.ts
+++ b/test/utils/templateCommand.test.ts
@@ -4,3 +4,43 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+import { expect } from 'chai';
+import { ConfigAggregator } from '@salesforce/core';
+import { getCustomTemplates } from '../../src/utils/templateCommand.js';
+
+describe('getCustomTemplates', () => {
+  it('should still return the value when set locally (with deprecation warning)', () => {
+    const mockAggregator = {
+      getInfo: () => ({
+        value: '/some/local/path',
+        isLocal: () => true,
+        isGlobal: () => false,
+      }),
+    } as unknown as ConfigAggregator;
+
+    expect(getCustomTemplates(mockAggregator)).to.equal('/some/local/path');
+  });
+
+  it('should return the value when set globally', () => {
+    const mockAggregator = {
+      getInfo: () => ({
+        value: '/Users/me/.custom-templates',
+        isLocal: () => false,
+        isGlobal: () => true,
+      }),
+    } as unknown as ConfigAggregator;
+
+    expect(getCustomTemplates(mockAggregator)).to.equal('/Users/me/.custom-templates');
+  });
+
+  it('should return undefined when config key is not set', () => {
+    const mockAggregator = {
+      getInfo: () => {
+        throw new Error('Unknown config name');
+      },
+    } as unknown as ConfigAggregator;
+
+    expect(getCustomTemplates(mockAggregator)).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Summary
- Emits a deprecation warning when `org-custom-metadata-templates` is read from local project config (`.sf/config.json`)
- The value is still honored (non-breaking) but users are directed to use `sf config set --global` instead
- A future release will stop honoring local config values for this setting entirely

## Security Context
@W-23595931@ — A malicious repository can commit `.sf/config.json` with `org-custom-metadata-templates` pointing to attacker-controlled EJS templates that achieve RCE.

The actual RCE mitigation is in `salesforcedx-templates` (template content validation). This PR signals the upcoming breaking change where local config will be disallowed for this setting.

Companion PR: https://github.com/forcedotcom/salesforcedx-templates/pull/875 (template validation — the actual RCE fix)

## Proof of Work
- Tests: 11 passing (3 new unit tests for `getCustomTemplates`)
- Lint: clean (1 pre-existing warning in unrelated file)
- Type check: clean

## Test plan
- [ ] Verify `sf config set org-custom-metadata-templates=/path` in `.sf/config.json` still works but emits deprecation warning
- [ ] Verify `sf config set --global org-custom-metadata-templates=/path` works without warning
- [ ] Verify no warning when the config key is not set at all